### PR TITLE
Add slash command prompts and vacuous green TDD fix

### DIFF
--- a/1. Plan/1a Analyze to determine approach for achieving the goal.md
+++ b/1. Plan/1a Analyze to determine approach for achieving the goal.md
@@ -9,6 +9,8 @@
 
 If provided, run this prompt in "Planning mode"
 
+> **Tool check:** Before running this analysis, does Claude Code have a command to explore codebase structure to support pattern discovery? (e.g., `/codebase-memory-exploring`) Would entering a planning mode help scope this analysis? (e.g., `/plan`)
+
 ---
 ``` markdown
 
@@ -66,6 +68,8 @@ Based on the problem scope and architectural patterns discovered:
 **Output:** Provide a terse and clear understanding of the problem and the key unknowns that must be resolved before an approach can be chosen. Do not recommend specific libraries, tools, or implementation strategies without codebase evidence. Keep it at a human readable length and level of detail.
 
 ```
+
+> **Tool check:** Now that pattern discovery is complete, is there a Claude Code tool to trace how these patterns connect across the codebase? (e.g., `/codebase-memory-tracing`)
 
 **Refine the analysis with questions**
 

--- a/1. Plan/1b Create a detailed implementation plan.md
+++ b/1. Plan/1b Create a detailed implementation plan.md
@@ -61,7 +61,6 @@ Before behavioral steps begin, identify any structural cleanup required to make 
 
 _Plan is verbose and I don't add it to any tracking_
 
-
 ---
 
 ## License & Attribution

--- a/2. Do/2. Test Drive the Change.md
+++ b/2. Do/2. Test Drive the Change.md
@@ -51,6 +51,8 @@ Work through behaviors in this order:
 
 Never stop with only happy path coverage. All cases must be on the test list from the start.
 
+If the next test in sequence would pass trivially against the current stub (vacuous green), skip to the first test the stub cannot satisfy — that is the genuine RED. See `references/testing-anti-patterns.md` #7.
+
 **Test Scope — Which Level?**
 
 | Question | → |

--- a/2. Do/2. Test Drive the Change.md
+++ b/2. Do/2. Test Drive the Change.md
@@ -10,6 +10,8 @@
 
 If possible, rather than trigger a build, switch to agent mode and use this prompt to provide guidance to the build.
 
+> **Tool check:** Is there a Claude Code command to show you what has already changed, to confirm your baseline before writing any new code? (e.g., `/diff`)
+
 ---
 ```markdown
 
@@ -100,6 +102,8 @@ If production evidence (logs, metrics) proves a bug exists but unit tests pass:
   "Implementation finished, moving to CHECK phase."													
 ```
 
+
+> **Tool check:** Before committing, is there a Claude Code command to review what changed? (e.g., `/diff`) One to check code quality? (e.g., `/simplify`) If this step touches auth or data, one to catch security issues? (e.g., `/security-review`) Is context getting long and losing focus? (e.g., `/context`, `/compact`)
 
 If you notice the agent making changes without test driving, making sprawling edits, or otherwise breaking the rules of engagement then the model has lost context and you need to stop it and reign it back in.
 

--- a/2. Do/Testing Anti-Patterns.md
+++ b/2. Do/Testing Anti-Patterns.md
@@ -56,6 +56,16 @@ Treating integration coverage as optional cleanup after unit tests are written m
 
 ---
 
+## 7. Vacuous Greens
+
+A test that passes immediately against the current stub without any production code change. Vacuous greens feel like progress but provide no genuine RED phase — you cannot know the test is testing the right thing.
+
+*Diagnosis:* If the next test in sequence would pass trivially against the current stub, it is a vacuous green.
+
+*Rule:* Skip to the first test in your sequence that the current stub cannot satisfy — that is your genuine RED. Document the skipped tests as guards to add after real implementation replaces the stub. State the called shot for the test you are actually going to write, not the one you are skipping.
+
+---
+
 ## Quick Check Before Committing
 
 - [ ] Every assertion is on real behavior, not mock call counts

--- a/3. Check/3. Completeness Check.md
+++ b/3. Check/3. Completeness Check.md
@@ -8,6 +8,9 @@
 **Next step:** Retrospection (4) for continuous improvement
 
 ---
+
+> **Tool check:** Before running this check, is there a Claude Code command to see all uncommitted changes? (e.g., `/diff`)
+
 ```
 **Completeness Check**
 
@@ -38,6 +41,8 @@ Review our original goal outcome and plan against our execution.
 **Ready to close:** [Yes/No with reasoning]
 
 ```
+
+> **Tool check:** Is there a Claude Code tool to surface code quality improvements in what changed? (e.g., `/simplify`) One to catch security concerns? (e.g., `/security-review`)
 
 Add Results to Ticket.
 

--- a/4. Act/4. Retrospect for continuous improvement.md
+++ b/4. Act/4. Retrospect for continuous improvement.md
@@ -9,6 +9,7 @@
 **Critical:** Capture learnings while session details are fresh
 
 ---
+
 ## 5. Retrospection
 
 ```markdown


### PR DESCRIPTION
## Summary

- Embeds Socratic tool-check callouts at 6 natural pause points across all PDCA phases, nudging the human to consider relevant Claude Code slash commands at the right moments
- Adds Vacuous Greens as anti-pattern #7 and a sequencing rule to the DO prompt, fixing a flaky eval scenario

## Changes

**Slash command prompts** (human-facing, outside code blocks):
- 1a: before analysis (/plan); after pattern discovery (/codebase-memory-tracing)
- DO: before writing code (/diff); before commit (/diff, /simplify, /security-review)
- CHECK: before verification (/diff); at structural review (/simplify, /security-review)

Prompts describe the need functionally with current command names as examples in parentheses, keeping them valid as Claude Code evolves.

**Vacuous greens fix:**
- Added anti-pattern #7 (Vacuous Greens) to Testing Anti-Patterns.md
- Added one-line sequencing rule to DO prompt referencing it
- Eval 2-after-passing-test GEval: 1/3 shots passing to 3/3 shots passing

## Test plan

- [x] 100/100 unit tests passing
- [x] DO phase evals: 2-after-passing-test GEval 3/3 shots passed
- [x] All other eval scenarios unchanged

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)