### PR TITLE
chore: replace CC0 with dual license (CC BY 4.0 + MIT)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,121 +1,43 @@
-Creative Commons Legal Code
+# Dual License
 
-CC0 1.0 Universal
+This repository uses two licenses depending on the type of content.
 
-    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
-    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
-    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
-    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
-    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
-    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
-    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
-    HEREUNDER.
+## Documentation and Prompts — Creative Commons Attribution 4.0 International (CC BY 4.0)
 
-Statement of Purpose
+All documentation, prompt files, and written content in this repository — including
+files in `1. Plan/`, `2. Do/`, `3. Check/`, `4. Act/`, `5. Scaffold/`,
+`Human Working Agreements.md`, `SKILL.md` files, and `README.md` — are licensed
+under the Creative Commons Attribution 4.0 International License.
 
-The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator
-and subsequent owner(s) (each and all, an "owner") of an original work of
-authorship and/or a database (each, a "Work").
+You are free to share and adapt this material for any purpose, including commercially,
+provided you give appropriate credit, provide a link to the license, and indicate
+if changes were made.
 
-Certain owners wish to permanently relinquish those rights to a Work for
-the purpose of contributing to a commons of creative, cultural and
-scientific works ("Commons") that the public can reliably and without fear
-of later claims of infringement build upon, modify, incorporate in other
-works, reuse and redistribute as freely as possible in any form whatsoever
-and for any purposes, including without limitation commercial purposes.
-These owners may contribute to the Commons to promote the ideal of a free
-culture and the further production of creative, cultural and scientific
-works, or to gain reputation or greater distribution for their Work in
-part through the use and efforts of others.
+Full license text: https://creativecommons.org/licenses/by/4.0/
 
-For these and/or other purposes and motivations, and without any
-expectation of additional consideration or compensation, the person
-associating CC0 with a Work (the "Affirmer"), to the extent that he or she
-is an owner of Copyright and Related Rights in the Work, voluntarily
-elects to apply CC0 to the Work and publicly distribute the Work under its
-terms, with knowledge of his or her Copyright and Related Rights in the
-Work and the meaning and intended legal effect of CC0 on those rights.
+---
 
-1. Copyright and Related Rights. A Work made available under CC0 may be
-protected by copyright and related or neighboring rights ("Copyright and
-Related Rights"). Copyright and Related Rights include, but are not
-limited to, the following:
+## Code — MIT License
 
-  i. the right to reproduce, adapt, distribute, perform, display,
-     communicate, and translate a Work;
- ii. moral rights retained by the original author(s) and/or performer(s);
-iii. publicity and privacy rights pertaining to a person's image or
-     likeness depicted in a Work;
- iv. rights protecting against unfair competition in regards to a Work,
-     subject to the limitations in paragraph 4(a), below;
-  v. rights protecting the extraction, dissemination, use and reuse of data
-     in a Work;
- vi. database rights (such as those arising under Directive 96/9/EC of the
-     European Parliament and of the Council of 11 March 1996 on the legal
-     protection of databases, and under any national implementation
-     thereof, including any amended or successor version of such
-     directive); and
-vii. other similar, equivalent or corresponding rights throughout the
-     world based on applicable law or treaty, and any national
-     implementations thereof.
+All source code in this repository — including files in `claude-skill/`, shell scripts,
+Python files, and build artifacts — is licensed under the MIT License.
 
-2. Waiver. To the greatest extent permitted by, but not in contravention
-of, applicable law, Affirmer hereby overtly, fully, permanently,
-irrevocably and unconditionally waives, abandons, and surrenders all of
-Affirmer's Copyright and Related Rights and associated claims and causes
-of action, whether now known or unknown (including existing as well as
-future claims and causes of action), in the Work (i) in all territories
-worldwide, (ii) for the maximum duration provided by applicable law or
-treaty (including future time extensions), (iii) in any current or future
-medium and for any number of copies, and (iv) for any purpose whatsoever,
-including without limitation commercial, advertising or promotional
-purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
-member of the public at large and to the detriment of Affirmer's heirs and
-successors, fully intending that such Waiver shall not be subject to
-revocation, rescission, cancellation, termination, or any other legal or
-equitable action to disrupt the quiet enjoyment of the Work by the public
-as contemplated by Affirmer's express Statement of Purpose.
+Copyright (c) 2024-2026 Ken Judy
 
-3. Public License Fallback. Should any part of the Waiver for any reason
-be judged legally invalid or ineffective under applicable law, then the
-Waiver shall be preserved to the maximum extent permitted taking into
-account Affirmer's express Statement of Purpose. In addition, to the
-extent the Waiver is so judged Affirmer hereby grants to each affected
-person a royalty-free, non transferable, non sublicensable, non exclusive,
-irrevocable and unconditional license to exercise Affirmer's Copyright and
-Related Rights in the Work (i) in all territories worldwide, (ii) for the
-maximum duration provided by applicable law or treaty (including future
-time extensions), (iii) in any current or future medium and for any number
-of copies, and (iv) for any purpose whatsoever, including without
-limitation commercial, advertising or promotional purposes (the
-"License"). The License shall be deemed effective as of the date CC0 was
-applied by Affirmer to the Work. Should any part of the License for any
-reason be judged legally invalid or ineffective under applicable law, such
-partial invalidity or ineffectiveness shall not invalidate the remainder
-of the License, and in such case Affirmer hereby affirms that he or she
-will not (i) exercise any of his or her remaining Copyright and Related
-Rights in the Work or (ii) assert any associated claims and causes of
-action with respect to the Work, in either case contrary to Affirmer's
-express Statement of Purpose.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-4. Limitations and Disclaimers.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
- a. No trademark or patent rights held by Affirmer are waived, abandoned,
-    surrendered, licensed or otherwise affected by this document.
- b. Affirmer offers the Work as-is and makes no representations or
-    warranties of any kind concerning the Work, express, implied,
-    statutory or otherwise, including without limitation warranties of
-    title, merchantability, fitness for a particular purpose, non
-    infringement, or the absence of latent or other defects, accuracy, or
-    the present or absence of errors, whether or not discoverable, all to
-    the greatest extent permissible under applicable law.
- c. Affirmer disclaims responsibility for clearing rights of other persons
-    that may apply to the Work or any use thereof, including without
-    limitation any person's Copyright and Related Rights in the Work.
-    Further, Affirmer disclaims responsibility for obtaining any necessary
-    consents, permissions or other rights required for any use of the
-    Work.
- d. Affirmer understands and acknowledges that Creative Commons is not a
-    party to this document and has no duty or obligation with respect to
-    this CC0 or use of the Work.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ New-Item -ItemType Directory -Path ".claude\prompts" -Force
 
 ## License
 
-This setup guide is part of the Human-AI PDCA Collaboration Process framework, licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+This repository uses a dual license. Documentation and prompts — including all files in the phase directories and `Human Working Agreements.md` — are licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Source code — including all files in `claude-skill/` — is licensed under the [MIT License](https://opensource.org/licenses/MIT). See [LICENSE](LICENSE) for full terms.
 
 **Attribution:** Ken Judy with Claude Anthropic
 

--- a/claude-skill/README.md
+++ b/claude-skill/README.md
@@ -420,7 +420,7 @@ This framework embodies agile principles:
 - **Responding to change** over following a plan (retrospection)
 
 ### Contributing
-The PDCA framework is open source under CC BY 4.0.
+The PDCA framework is open source under a dual license: CC BY 4.0 for documentation and prompts, MIT for source code.
 
 **Repository:** https://github.com/kenjudy/pdca-framework
 **Issues/Suggestions:** [Create GitHub issue](https://github.com/kenjudy/pdca-framework/issues/new)
@@ -448,7 +448,7 @@ Help improve the framework:
 ## Version Information
 
 **Current Version:** v1.1.0
-**License:** Creative Commons Attribution 4.0 International (CC BY 4.0)
+**License:** CC BY 4.0 (documentation & prompts) / MIT (source code)
 **Attribution:** Ken Judy with Claude Anthropic 4
 **Last Updated:** 2026-05-28
 


### PR DESCRIPTION
## Summary

- Replaces the CC0 1.0 Universal license with a dual license
- Documentation and prompts (phase directories, `Human Working Agreements.md`, `SKILL.md` files) are licensed under CC BY 4.0
- Source code (`claude-skill/`) is licensed under MIT
- Updates `LICENSE`, `README.md`, and `claude-skill/README.md` to reflect correct terms

## Test plan

- [ ] Verify `LICENSE` contains both CC BY 4.0 and MIT sections
- [ ] Verify `README.md` license section links to both licenses and points to `LICENSE`
- [ ] Verify `claude-skill/README.md` contributing and version info sections reflect dual license
- [ ] Confirm prompt files in phase directories still carry CC BY 4.0 (no changes needed there)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)