### PR TITLE
Drop over-broad "complete" signal from 2-first-step (#112)

### DIFF
--- a/skill/eval/rubrics/rubric_2.py
+++ b/skill/eval/rubrics/rubric_2.py
@@ -17,7 +17,12 @@ Key behaviors evaluated:
 
 Why these signals:
 - called_shot_required covers the structural presence of all 4 fields mechanically
-- must_not_contain ["complete", "all done", "we're done"] enforces the hard STOP word rule
+- must_not_contain guards against *declaring* completion, per scenario: ["all done"] on
+  2-first-step / 2-beads-ordering-capture / 2-ponytail-precedence, and the fuller set on
+  2-after-passing-test. The bare stem "complete" was removed (#112) because it also matched
+  the ordinary adjective — "here's the complete sequence" is the behavior the prompt asks
+  for, and the check scored it as a violation. Whether a response *declares* completion is a
+  semantic judgment, so it lives in CRITERIA #5 below rather than in the mechanical tier.
 - must_contain called shot fields: critical for catching the "skip tests" scenario where the
   model might write code without following the called shot protocol
 - GEval adds coverage for sequencing (degenerate first), refusal to skip, and general

--- a/skill/eval/scenarios/2_scenarios.json
+++ b/skill/eval/scenarios/2_scenarios.json
@@ -7,7 +7,6 @@
     "expected_signals": {
       "must_contain": [],
       "must_not_contain": [
-        "complete",
         "all done"
       ],
       "called_shot_required": false


### PR DESCRIPTION
Closes #112.

Two files: one array element removed, one docstring corrected. No new test.

## The defect

The DO prompt forbids *declaring* completion:

> ⚠️ **STOP**: Do not declare "complete" or "done". Say "Implementation finished, moving to CHECK phase."

`2-first-step` transliterated that into `must_not_contain: ["complete", "all done"]`, which keeps the words in quotes but drops the verb. As a bare stem it matches the ordinary adjective. Observed live:

```
Before writing any test, here's the complete sequence:
```

That is a model listing its planned tests up front — exactly what the DO prompt asks for — scored as a discipline violation. It also matched "completeness", "completed", "completion".

## Why removal rather than narrowing

The issue suggested narrowing to `["Implementation complete", "work is complete", "task complete", "all done"]`. Rejected, for two reasons.

**We would have been guessing.** The prompt hands the model the approved phrasing, so a compliant model never emits any of those. What a *violating* model emits is unknown — inventing four phrasings risks a guard that is green forever because it cannot fire, which is exactly the `must_not_contain: "Status: Complete"` defect that #111 existed to fix. The signal-validation rule added in #115 requires non-vacuity be *demonstrated*, and here it could not be.

**The dimension is already covered at the right tier.** `rubric_2.py` addresses premature completion in four places — key behavior #4, CRITERIA requirement #5, the Weaknesses prompt, and both scoring anchors (1.0 requires not declaring done; 0.0 explicitly includes "declares the work complete"). Whether "here's the complete sequence" is a completion declaration depends on what it is the complete sequence *of* — a semantic judgment, which the Signal Selection Guide assigns to GEval, not to string matching.

So this is a tier migration, not a coverage loss.

## Why the element and not the whole guard

Removing the entire `must_not_contain` would leave `2-first-step` with zero mechanical signals (`must_contain: []`, `called_shot_required: false`) — GEval-only, stochastic, ~$0.15–0.40 per run.

Removing just `"complete"` lands it on the pattern already used by two sibling scenarios:

| Scenario | `must_not_contain` |
|---|---|
| `2-beads-ordering-capture` | `["all done"]` |
| `2-ponytail-precedence` | `["all done"]` |
| `2-first-step` (this PR) | `["all done"]` |

No new signal is introduced, so no non-vacuity demonstration is owed.

## Sibling audit

All 32 `must_not_contain` signals across the five scenario files were inventoried. `"complete"` was the only bare-stem signal. Two things worth recording:

- `2-after-passing-test` forbids `"Implementation finished, moving to CHECK phase"` — the phrase the prompt *requires*. **Not a contradiction:** that scenario is mid-cycle (test 2 of 5), so declaring completion there is premature and forbidding it is correct.
- `4-tdd-breakdown` carries `"you should"`, which is phrase-shaped but common in ordinary prose. Same class as #112, lower severity, left alone.

## Verification

No TDD — this removes a defective datum rather than driving out behavior.

Replaying the recorded string from #112 through `check_mechanical` against the live scenario signal:

| Signal | Result |
|---|---|
| `["complete", "all done"]` | `'complete' FOUND (bad)` → fails |
| `["all done"]` | `'all done' absent (good)` → passes |

Gates: 148 passed, 153 subtests, ruff and mypy clean.

No eval run. This is phase-2 scenario data, so `TestPrompt2Evals` is the affected class, but running it would cost ~$2–5 to watch a passing scenario keep passing on a stochastic judge — against a baseline that already contains one scenario too unstable to compare against. The string replay is decisive and free.

## Docstring correction

`rubric_2.py`'s "Why these signals" note listed `["complete", "all done", "we're done"]` as one signal set. It never was — `"we're done"` appears only in `2-after-passing-test`. Corrected to describe the per-scenario reality and to record why the semantic judgment lives in CRITERIA rather than the mechanical tier.

## Follow-up filed

**#116** — the surviving `"all done"` signal is case-sensitive and misses the sentence-initial "All done", which is the natural phrasing. Found by probing whether the guard could still fire, not by a failure. It becomes load-bearing after this PR, since `["all done"]` is now `2-first-step`'s only mechanical signal. Filed separately because the fix is a matcher-semantics decision affecting all 32 signals, which would make this change stop being minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_